### PR TITLE
Created solid navigation base

### DIFF
--- a/KeyboardKing.sln
+++ b/KeyboardKing.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31624.102
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeyboardKing", "KeyboardKing\KeyboardKing.csproj", "{1616F9BF-38CD-42B7-A463-5A4D836A7360}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1616F9BF-38CD-42B7-A463-5A4D836A7360}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1616F9BF-38CD-42B7-A463-5A4D836A7360}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1616F9BF-38CD-42B7-A463-5A4D836A7360}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1616F9BF-38CD-42B7-A463-5A4D836A7360}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0D6A3387-1437-4A67-AD75-730F3D0F15C0}
+	EndGlobalSection
+EndGlobal

--- a/KeyboardKing/App.xaml
+++ b/KeyboardKing/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="KeyboardKing.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:KeyboardKing"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/KeyboardKing/App.xaml.cs
+++ b/KeyboardKing/App.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace KeyboardKing
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+}

--- a/KeyboardKing/AssemblyInfo.cs
+++ b/KeyboardKing/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]

--- a/KeyboardKing/KeyboardKing.csproj
+++ b/KeyboardKing/KeyboardKing.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net5.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+</Project>

--- a/KeyboardKing/MainWindow.xaml
+++ b/KeyboardKing/MainWindow.xaml
@@ -1,0 +1,12 @@
+﻿<Window x:Class="KeyboardKing.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:KeyboardKing"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+        <Frame x:Name="MainFrame" NavigationUIVisibility="Hidden" Background="Black"/>
+    </Grid>
+</Window>

--- a/KeyboardKing/MainWindow.xaml.cs
+++ b/KeyboardKing/MainWindow.xaml.cs
@@ -1,0 +1,71 @@
+﻿using KeyboardKing.areas.login;
+using KeyboardKing.areas.main;
+using KeyboardKing.areas.play;
+using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        /// <summary>
+        /// Frame element that is used to display the pages.
+        /// </summary>
+        private Frame _mainFrame {get;set;}
+
+        /// <summary>
+        /// Dictionary of pages that are used in the app.
+        /// </summary>
+        private Dictionary<string, JumpPage> _pages {get;set;}
+
+        public MainWindow()
+        {
+            InitializeComponent();
+
+            _mainFrame = MainFrame;
+            _pages = new()
+            {
+                // login area
+                {"LoginPage", new LoginPage(this)},
+                {"RegisterPage1", new RegisterPage1(this)},
+                {"RegisterPage2", new RegisterPage2(this)},
+
+                // main area
+                {"ChaptersPage", new ChaptersPage(this)},
+                {"FavoritesPage", new FavoritesPage(this)},
+                {"SettingsPage", new SettingsPage(this)},
+
+                // play area
+                {"EpisodePage", new EpisodePage(this)},
+                {"EpisodeResultPage", new EpisodeResultPage(this)},
+                {"MatchLobbyPage", new MatchLobbyPage(this)},
+                {"MatchPlayingPage", new MatchPlayingPage(this)},
+                {"MatchResultPage", new MatchResultPage(this)},
+            };
+
+            // Navigate to the first view.
+            Navigate("LoginPage");
+        }
+
+        public void Navigate(string pageName)
+        {
+            _mainFrame.Navigate(_pages[pageName]);
+        }
+    }
+}

--- a/KeyboardKing/areas/login/LoginPage.xaml
+++ b/KeyboardKing/areas/login/LoginPage.xaml
@@ -1,0 +1,14 @@
+﻿<local:JumpPage x:Class="KeyboardKing.areas.login.LoginPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:KeyboardKing.core"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="LoginPage">
+    <Grid>
+        <Label Content="LoginPage" HorizontalAlignment="Left" Margin="49,51,0,0" VerticalAlignment="Top" Foreground="White" FontSize="36"/>
+        <Button Content="Ga naar register" Tag="RegisterPage1" Click="ButtonNavigate" HorizontalAlignment="Left" Margin="49,114,0,0" VerticalAlignment="Top" Height="81" Width="227" Background="#FF363636" BorderBrush="White" Foreground="White" FontSize="20"/>
+    </Grid>
+</local:JumpPage>

--- a/KeyboardKing/areas/login/LoginPage.xaml.cs
+++ b/KeyboardKing/areas/login/LoginPage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing.areas.login
+{
+    /// <summary>
+    /// Interaction logic for LoginPage.xaml
+    /// </summary>
+    public partial class LoginPage : JumpPage
+    {
+        public LoginPage(MainWindow w) : base(w)
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/KeyboardKing/areas/login/RegisterPage1.xaml
+++ b/KeyboardKing/areas/login/RegisterPage1.xaml
@@ -1,0 +1,14 @@
+﻿<local:JumpPage x:Class="KeyboardKing.areas.login.RegisterPage1"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:KeyboardKing.core"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="RegisterPage1">
+    <Grid>
+        <Label Content="RegisterPage1" HorizontalAlignment="Left" Margin="49,51,0,0" VerticalAlignment="Top" Foreground="White" FontSize="36"/>
+        <Button Content="Ga naar login" Tag="LoginPage" Click="ButtonNavigate" HorizontalAlignment="Left" Margin="49,114,0,0" VerticalAlignment="Top" Height="81" Width="227" Background="#FF363636" BorderBrush="White" Foreground="White" FontSize="20"/>
+    </Grid>
+</local:JumpPage>

--- a/KeyboardKing/areas/login/RegisterPage1.xaml.cs
+++ b/KeyboardKing/areas/login/RegisterPage1.xaml.cs
@@ -1,0 +1,29 @@
+﻿using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing.areas.login
+{
+    /// <summary>
+    /// Interaction logic for RegisterPage1.xaml
+    /// </summary>
+    public partial class RegisterPage1 : JumpPage
+    {
+        public RegisterPage1(MainWindow w) : base(w)
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/KeyboardKing/areas/login/RegisterPage2.xaml
+++ b/KeyboardKing/areas/login/RegisterPage2.xaml
@@ -1,0 +1,13 @@
+﻿<local:JumpPage x:Class="KeyboardKing.areas.login.RegisterPage2"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:KeyboardKing.core"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="RegisterPage2">
+    <Grid>
+        <Label Content="RegisterPage2" HorizontalAlignment="Left" Margin="49,51,0,0" VerticalAlignment="Top" Foreground="White" FontSize="36"/>
+    </Grid>
+</local:JumpPage>

--- a/KeyboardKing/areas/login/RegisterPage2.xaml.cs
+++ b/KeyboardKing/areas/login/RegisterPage2.xaml.cs
@@ -1,0 +1,29 @@
+﻿using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing.areas.login
+{
+    /// <summary>
+    /// Interaction logic for RegisterPage2.xaml
+    /// </summary>
+    public partial class RegisterPage2 : JumpPage
+    {
+        public RegisterPage2(MainWindow w) : base(w)
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/KeyboardKing/areas/main/ChaptersPage.xaml
+++ b/KeyboardKing/areas/main/ChaptersPage.xaml
@@ -1,0 +1,13 @@
+﻿<local:JumpPage x:Class="KeyboardKing.areas.main.ChaptersPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:KeyboardKing.core"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="ChaptersPage">
+    <Grid>
+        <Label Content="ChaptersPage" HorizontalAlignment="Left" Margin="49,51,0,0" VerticalAlignment="Top" Foreground="White" FontSize="36"/>
+    </Grid>
+</local:JumpPage>

--- a/KeyboardKing/areas/main/ChaptersPage.xaml.cs
+++ b/KeyboardKing/areas/main/ChaptersPage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing.areas.main
+{
+    /// <summary>
+    /// Interaction logic for ChaptersPage.xaml
+    /// </summary>
+    public partial class ChaptersPage : JumpPage
+    {
+        public ChaptersPage(MainWindow w) : base(w)
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/KeyboardKing/areas/main/FavoritesPage.xaml
+++ b/KeyboardKing/areas/main/FavoritesPage.xaml
@@ -1,0 +1,14 @@
+﻿<local:JumpPage x:Class="KeyboardKing.areas.main.FavoritesPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:KeyboardKing.core"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="FavoritesPage">
+
+    <Grid>
+        <Label Content="FavoritesPage" HorizontalAlignment="Left" Margin="49,51,0,0" VerticalAlignment="Top" Foreground="White" FontSize="36"/>
+    </Grid>
+</local:JumpPage>

--- a/KeyboardKing/areas/main/FavoritesPage.xaml.cs
+++ b/KeyboardKing/areas/main/FavoritesPage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing.areas.main
+{
+    /// <summary>
+    /// Interaction logic for FavoritesPage.xaml
+    /// </summary>
+    public partial class FavoritesPage : JumpPage
+    {
+        public FavoritesPage(MainWindow w) : base(w)
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/KeyboardKing/areas/main/SettingsPage.xaml
+++ b/KeyboardKing/areas/main/SettingsPage.xaml
@@ -1,0 +1,13 @@
+﻿<local:JumpPage x:Class="KeyboardKing.areas.main.SettingsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:KeyboardKing.core"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="SettingsPage">
+    <Grid>
+        <Label Content="SettingsPage" HorizontalAlignment="Left" Margin="49,51,0,0" VerticalAlignment="Top" Foreground="White" FontSize="36"/>
+    </Grid>
+</local:JumpPage>

--- a/KeyboardKing/areas/main/SettingsPage.xaml.cs
+++ b/KeyboardKing/areas/main/SettingsPage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing.areas.main
+{
+    /// <summary>
+    /// Interaction logic for SettingsPage.xaml
+    /// </summary>
+    public partial class SettingsPage : JumpPage
+    {
+        public SettingsPage(MainWindow w) : base(w)
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/KeyboardKing/areas/play/EpisodePage.xaml
+++ b/KeyboardKing/areas/play/EpisodePage.xaml
@@ -1,0 +1,14 @@
+﻿<local:JumpPage x:Class="KeyboardKing.areas.play.EpisodePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:KeyboardKing.core"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="EpisodePage">
+
+    <Grid>
+        <Label Content="EpisodePage" HorizontalAlignment="Left" Margin="49,51,0,0" VerticalAlignment="Top" Foreground="White" FontSize="36"/>
+    </Grid>
+</local:JumpPage>

--- a/KeyboardKing/areas/play/EpisodePage.xaml.cs
+++ b/KeyboardKing/areas/play/EpisodePage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing.areas.play
+{
+    /// <summary>
+    /// Interaction logic for EpisodePage.xaml
+    /// </summary>
+    public partial class EpisodePage : JumpPage
+    {
+        public EpisodePage(MainWindow w) : base(w)
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/KeyboardKing/areas/play/EpisodeResultPage.xaml
+++ b/KeyboardKing/areas/play/EpisodeResultPage.xaml
@@ -1,0 +1,14 @@
+﻿<local:JumpPage x:Class="KeyboardKing.areas.play.EpisodeResultPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:KeyboardKing.core"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="EpisodeResultPage">
+
+    <Grid>
+        <Label Content="EpisodeResultPage" HorizontalAlignment="Left" Margin="49,51,0,0" VerticalAlignment="Top" Foreground="White" FontSize="36"/>
+    </Grid>
+</local:JumpPage>

--- a/KeyboardKing/areas/play/EpisodeResultPage.xaml.cs
+++ b/KeyboardKing/areas/play/EpisodeResultPage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing.areas.play
+{
+    /// <summary>
+    /// Interaction logic for EpisodeResultPage.xaml
+    /// </summary>
+    public partial class EpisodeResultPage : JumpPage
+    {
+        public EpisodeResultPage(MainWindow w) : base(w)
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/KeyboardKing/areas/play/MatchLobbyPage.xaml
+++ b/KeyboardKing/areas/play/MatchLobbyPage.xaml
@@ -1,0 +1,14 @@
+﻿<local:JumpPage x:Class="KeyboardKing.areas.play.MatchLobbyPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:KeyboardKing.core"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="MatchLobbyPage">
+
+    <Grid>
+        <Label Content="MatchLobbyPage" HorizontalAlignment="Left" Margin="49,51,0,0" VerticalAlignment="Top" Foreground="White" FontSize="36"/>
+    </Grid>
+</local:JumpPage>

--- a/KeyboardKing/areas/play/MatchLobbyPage.xaml.cs
+++ b/KeyboardKing/areas/play/MatchLobbyPage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing.areas.play
+{
+    /// <summary>
+    /// Interaction logic for MatchLobbyPage.xaml
+    /// </summary>
+    public partial class MatchLobbyPage : JumpPage
+    {
+        public MatchLobbyPage(MainWindow w) : base(w)
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/KeyboardKing/areas/play/MatchPlayingPage.xaml
+++ b/KeyboardKing/areas/play/MatchPlayingPage.xaml
@@ -1,0 +1,14 @@
+﻿<local:JumpPage x:Class="KeyboardKing.areas.play.MatchPlayingPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:KeyboardKing.core"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="MatchPlayingPage">
+
+    <Grid>
+        <Label Content="MatchPlayingPage" HorizontalAlignment="Left" Margin="49,51,0,0" VerticalAlignment="Top" Foreground="White" FontSize="36"/>
+    </Grid>
+</local:JumpPage>

--- a/KeyboardKing/areas/play/MatchPlayingPage.xaml.cs
+++ b/KeyboardKing/areas/play/MatchPlayingPage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing.areas.play
+{
+    /// <summary>
+    /// Interaction logic for MatchPlayingPage.xaml
+    /// </summary>
+    public partial class MatchPlayingPage : JumpPage
+    {
+        public MatchPlayingPage(MainWindow w) : base(w)
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/KeyboardKing/areas/play/MatchResultPage.xaml
+++ b/KeyboardKing/areas/play/MatchResultPage.xaml
@@ -1,0 +1,14 @@
+﻿<local:JumpPage x:Class="KeyboardKing.areas.play.MatchResultPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:KeyboardKing.core"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="MatchResultPage">
+
+    <Grid>
+        <Label Content="MatchResultPage" HorizontalAlignment="Left" Margin="49,51,0,0" VerticalAlignment="Top" Foreground="White" FontSize="36"/>
+    </Grid>
+</local:JumpPage>

--- a/KeyboardKing/areas/play/MatchResultPage.xaml.cs
+++ b/KeyboardKing/areas/play/MatchResultPage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using KeyboardKing.core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace KeyboardKing.areas.play
+{
+    /// <summary>
+    /// Interaction logic for MatchResultPage.xaml
+    /// </summary>
+    public partial class MatchResultPage : JumpPage
+    {
+        public MatchResultPage(MainWindow w) : base(w)
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/KeyboardKing/core/JumpPage.cs
+++ b/KeyboardKing/core/JumpPage.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace KeyboardKing.core
+{
+    public class JumpPage : Page
+    {
+        /// <summary>
+        /// Parent Window that contains the Frame.
+        /// </summary>
+        private MainWindow _window {get;set;}
+
+        public JumpPage(MainWindow w)
+        {
+            _window = w;
+        }
+
+        /// <summary>
+        /// Use the parent window to navigate by name.
+        /// </summary>
+        public void Navigate(string pageName)
+        {
+            _window.Navigate(pageName);
+        }
+
+        /// <summary>
+        /// Use the parent window to navigate by button tag.
+        /// Tag="TargetPageName" Click="ButtonNavigate"
+        /// </summary>
+        public void ButtonNavigate(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button)
+            {
+                _window.Navigate("" + ((Button)sender).Tag);
+            }
+        }
+    }
+}

--- a/KeyboardKing/core/JumpPage.cs
+++ b/KeyboardKing/core/JumpPage.cs
@@ -8,7 +8,7 @@ using System.Windows.Controls;
 
 namespace KeyboardKing.core
 {
-    public class JumpPage : Page
+    public abstract class JumpPage : Page
     {
         /// <summary>
         /// Parent Window that contains the Frame.


### PR DESCRIPTION
Added:
- MainWindow.Navigate(string pageName)
- MainWindow._pages
- JumpPage class
- JumpPage.Navigate(string pageName)
- JumpPage.Navigate(object sender, RoutedEventArgs e)

MainWindow.Navigate, used to navigate between _pages.
_pages contains several JumpPages, aka all the views.
JumpPage.Navigate uses MainWindow.Navigate to change the view.

<hr>

Navigation can be done in 3 ways:

From MainWindow
![image](https://user-images.githubusercontent.com/42808385/142064661-1595d832-a83c-4e16-8faa-efa51b905afb.png)

From JumpPage buttons
![image](https://user-images.githubusercontent.com/42808385/142064767-87f731e3-3804-4ecd-985c-1d36ba97c02c.png)

From JumpPage code
![image](https://user-images.githubusercontent.com/42808385/142064892-a7ff4417-149b-4763-8666-5b3676d5b907.png)

<hr>

See:
- [MainWindow.xaml.cs](https://github.com/Juastin/KeyboardKing/blob/Routing/KeyboardKing/MainWindow.xaml.cs)
- [LoginPage.xaml](https://github.com/Juastin/KeyboardKing/blob/Routing/KeyboardKing/areas/login/LoginPage.xaml), [RegisterPage1.xaml](https://github.com/Juastin/KeyboardKing/blob/Routing/KeyboardKing/areas/login/RegisterPage1.xaml)
- [LoginPage.xaml.cs](https://github.com/Juastin/KeyboardKing/blob/Routing/KeyboardKing/areas/login/LoginPage.xaml.cs)
- [RegisterPage1.xaml.cs](https://github.com/Juastin/KeyboardKing/blob/Routing/KeyboardKing/areas/login/RegisterPage1.xaml.cs)