### PR TITLE
temp hide points and match layout of both playpages

### DIFF
--- a/KeyboardKing/areas/play/EpisodePage.xaml
+++ b/KeyboardKing/areas/play/EpisodePage.xaml
@@ -18,79 +18,72 @@
     </local:JumpPage.DataContext>
 
     <Grid x:Name="Container" Margin="25">
-        <Border Style="{DynamicResource GridBorder}"/>
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <TextBox x:Name="UserInput" Background="Transparent" Foreground="Transparent" CaretBrush="Transparent" Grid.RowSpan="4" LostKeyboardFocus="UserInput_LostFocus" Text="" TextChanged="UserInput_TextChanged" SelectionBrush="{x:Null}" BorderThickness="0,0,0,0"/>
-            <Grid Grid.Row="0">
-                <TextBox x:Name="TimerTextBox" Style="{DynamicResource TextBox2}" VerticalAlignment="Top" Background="Transparent"  Text="00:00" Height="53"  Margin="10,11,133,0"/>
-                <Button Style="{DynamicResource Button1}" Content="Pauze" VerticalAlignment="Top" HorizontalAlignment="Right" Click="ButtonPause" FontSize="26" Margin="0,11,10,0"  Height="54" Width="110"/>
-            </Grid>
-            <Grid Grid.Row="1">
-                <Border CornerRadius="80" Background="#ffffff" BorderBrush="#2a3b57" 
-                BorderThickness="5" Height="91" Margin="10"
-                Name="Border1" VerticalAlignment="Top" HorizontalAlignment="Center" Width="136">
-                    <TextBlock x:Name="points" Background="Transparent" HorizontalAlignment="Center"
-                       VerticalAlignment="Center" Height="40" Width="116"
-                       TextWrapping="Wrap" Text="0p" FontSize="32" TextAlignment="Center">
-                    </TextBlock>
-                </Border>
-            </Grid>
-            <Grid Margin="100,0" Grid.Row="1" Grid.RowSpan="2" HorizontalAlignment="Center" VerticalAlignment="Center" TextOptions.TextFormattingMode="Display">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition/>
-                    <ColumnDefinition/>
-                </Grid.ColumnDefinitions>
-                <Grid.OpacityMask>
-                    <LinearGradientBrush EndPoint="1,0"
-                             StartPoint="0,0">
-                        <GradientStop Color="Transparent"
-                                              Offset="0" />
-                        <GradientStop Color="White" 
-                                              Offset="0.02"/>
-                        <GradientStop Color="White"
-                                              Offset="0.98" />
-                        <GradientStop Color="Transparent" 
-                                              Offset="1"/>
-                    </LinearGradientBrush>
-                </Grid.OpacityMask>
-                <Grid>
-                    <TextBlock VerticalAlignment="Center" HorizontalAlignment="Right" FontSize="50" x:Name="WordOverlayCorrect" Text="{Binding WordOverlayCorrect}" Foreground="Green"/>
+        <Border Style="{DynamicResource GridBorder}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <TextBox x:Name="UserInput" Background="Transparent" Foreground="Transparent" CaretBrush="Transparent" Grid.RowSpan="4" LostKeyboardFocus="UserInput_LostFocus" Text="" TextChanged="UserInput_TextChanged" SelectionBrush="{x:Null}" BorderThickness="0,0,0,0"/>
+                <Grid Grid.Row="0" Margin="30,30,30,0">
+                    <TextBlock Visibility="Hidden" Style="{DynamicResource TextBlock}" Background="Transparent" x:Name="points" HorizontalAlignment="Center"
+                    VerticalAlignment="Top" Height="40" Width="116"
+                    TextWrapping="Wrap" Text="0p" TextAlignment="Center"/>
+                    <TextBox BorderThickness="0" x:Name="TimerTextBox" Style="{DynamicResource TextBox2}" VerticalAlignment="Center" Background="Transparent" Text="00:00"/>
+                    <Button Style="{DynamicResource Button1}" Content="Pauze" VerticalAlignment="Top" HorizontalAlignment="Right" Click="ButtonPause" FontSize="26" Width="110"/>
                 </Grid>
-                <Border Grid.Column="1" BorderThickness="3, 0, 0, 0">
-                    <Border.BorderBrush>
-                        <DrawingBrush Viewport="0,0,8,22" ViewportUnits="Absolute" TileMode="Tile">
-                            <DrawingBrush.Drawing>
-                                <DrawingGroup>
-                                    <GeometryDrawing Brush="{DynamicResource TextColor}">
-                                        <GeometryDrawing.Geometry>
-                                            <GeometryGroup>
-                                                <RectangleGeometry Rect="0,0,50,50" />
-                                                <RectangleGeometry Rect="50,50,0,50" />
-                                            </GeometryGroup>
-                                        </GeometryDrawing.Geometry>
-                                    </GeometryDrawing>
-                                </DrawingGroup>
-                            </DrawingBrush.Drawing>
-                        </DrawingBrush>
-                    </Border.BorderBrush>
-                    <Grid>
-                        <Label FontSize="50" x:Name="WordOverlay" Content="{Binding WordOverlay }" Foreground="{DynamicResource TextColor}"/>
-                        <Label FontSize="50" x:Name="WordOverlayWrong" Content="{Binding WordOverlayWrong}" Foreground="Red"/>
+                <Grid Margin="100,0" Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center" TextOptions.TextFormattingMode="Display">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.OpacityMask>
+                        <LinearGradientBrush EndPoint="1,0"
+                             StartPoint="0,0">
+                            <GradientStop Color="Transparent"
+                                              Offset="0" />
+                            <GradientStop Color="White" 
+                                              Offset="0.02"/>
+                            <GradientStop Color="White"
+                                              Offset="0.98" />
+                            <GradientStop Color="Transparent" 
+                                              Offset="1"/>
+                        </LinearGradientBrush>
+                    </Grid.OpacityMask>
+                    <Grid  Grid.Column="0">
+                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Right" FontSize="50" x:Name="WordOverlayCorrect" Text="{Binding WordOverlayCorrect}" Foreground="Green"/>
                     </Grid>
-                </Border>
-            </Grid>
-            <Grid Grid.Row="3">
-                <ProgressBar Background="{DynamicResource Color4}" Template="{DynamicResource ProgressBar}" 
+                    <Border Grid.Column="1" BorderThickness="3, 0, 0, 0">
+                        <Border.BorderBrush>
+                            <DrawingBrush Viewport="0,0,8,22" ViewportUnits="Absolute" TileMode="Tile">
+                                <DrawingBrush.Drawing>
+                                    <DrawingGroup>
+                                        <GeometryDrawing Brush="{DynamicResource TextColor}">
+                                            <GeometryDrawing.Geometry>
+                                                <GeometryGroup>
+                                                    <RectangleGeometry Rect="0,0,50,50" />
+                                                    <RectangleGeometry Rect="50,50,0,50" />
+                                                </GeometryGroup>
+                                            </GeometryDrawing.Geometry>
+                                        </GeometryDrawing>
+                                    </DrawingGroup>
+                                </DrawingBrush.Drawing>
+                            </DrawingBrush>
+                        </Border.BorderBrush>
+                        <Grid>
+                            <Label FontSize="50" x:Name="WordOverlay" Content="{Binding WordOverlay }" Foreground="{DynamicResource TextColor}"/>
+                            <Label FontSize="50" x:Name="WordOverlayWrong" Content="{Binding WordOverlayWrong}" Foreground="Red"/>
+                        </Grid>
+                    </Border>
+                </Grid>
+                <Grid Grid.Row="2">
+                    <ProgressBar Background="{DynamicResource Color4}" Template="{DynamicResource ProgressBar}" 
                          VerticalAlignment="Bottom" Height="20" Minimum="0" 
                          Maximum="{Binding MaxLetters}" 
                          Value="{Binding LettersTyped, Mode=OneWay}"/>
-            </Grid>         
-        </Grid>
+                </Grid>
+            </Grid>
+        </Border>
     </Grid>
 </local:JumpPage>

--- a/KeyboardKing/areas/play/MatchPlayingPage.xaml
+++ b/KeyboardKing/areas/play/MatchPlayingPage.xaml
@@ -6,7 +6,7 @@
       xmlns:local="clr-namespace:KeyboardKing.core" xmlns:model="clr-namespace:Model" d:DataContext="{d:DesignInstance Type=model:MatchPageDataContext}"
       mc:Ignorable="d" 
       d:DesignHeight="450" d:DesignWidth="800"
-      MaxHeight="600"
+      MaxHeight="750"
       MaxWidth="1450"
       Title="MatchPlayingPage" PreviewKeyDown="PreventTab_PreviewKeyDown" ForceCursor="True" Cursor="Arrow">
     <local:JumpPage.DataContext>
@@ -38,70 +38,79 @@
         </Style>
     </Page.Resources>
 
-    <Grid x:Name="Container">
-        <Border Style="{DynamicResource GridBorder}"/>
-        <ListBox x:Name="OpponentListBox" ItemContainerStyle="{DynamicResource ListBoxItemTemplate}" Background="Transparent" BorderThickness="0" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,0,0,200">
-            <ListBox.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <UniformGrid Columns="2"/>
-                </ItemsPanelTemplate>
-            </ListBox.ItemsPanel>
-        </ListBox>
-        <Label Style="{DynamicResource H1}" Content="" Margin="49,51,301,336"/>
-        <TextBox x:Name="UserInput" Background="Transparent" Foreground="Transparent" CaretBrush="Transparent" Grid.Column="0" LostKeyboardFocus="UserInput_LostFocus" Text="" TextChanged="UserInput_TextChanged" SelectionBrush="{x:Null}" BorderThickness="0,0,0,0">
-        </TextBox>
-        <Grid Margin="100,0" Grid.Row="1" Grid.RowSpan="2" HorizontalAlignment="Center" VerticalAlignment="Center" TextOptions.TextFormattingMode="Display">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition/>
-                <ColumnDefinition/>
-            </Grid.ColumnDefinitions>
-            <Grid.OpacityMask>
-                <LinearGradientBrush EndPoint="1,0"
-                             StartPoint="0,0">
-                    <GradientStop Color="Transparent"
-                                              Offset="0" />
-                    <GradientStop Color="White" 
-                                              Offset="0.02"/>
-                    <GradientStop Color="White"
-                                              Offset="0.98" />
-                    <GradientStop Color="Transparent" 
-                                              Offset="1"/>
-                </LinearGradientBrush>
-            </Grid.OpacityMask>
+    <Grid x:Name="Container" Margin="25">
+        <Border Style="{DynamicResource GridBorder}">
             <Grid>
-                <TextBlock VerticalAlignment="Center" HorizontalAlignment="Right" FontSize="50" x:Name="WordOverlayCorrect" Text="{Binding WordOverlayCorrect}" Foreground="Green"/>
-            </Grid>
-            <Border Grid.Column="1" BorderThickness="3, 0, 0, 0">
-                <Border.BorderBrush>
-                    <DrawingBrush Viewport="0,0,8,22" ViewportUnits="Absolute" TileMode="Tile">
-                        <DrawingBrush.Drawing>
-                            <DrawingGroup>
-                                <GeometryDrawing Brush="{DynamicResource TextColor}">
-                                    <GeometryDrawing.Geometry>
-                                        <GeometryGroup>
-                                            <RectangleGeometry Rect="0,0,50,50" />
-                                            <RectangleGeometry Rect="50,50,0,50" />
-                                        </GeometryGroup>
-                                    </GeometryDrawing.Geometry>
-                                </GeometryDrawing>
-                            </DrawingGroup>
-                        </DrawingBrush.Drawing>
-                    </DrawingBrush>
-                </Border.BorderBrush>
-                <Grid>
-                    <Label FontSize="50" x:Name="WordOverlay" Content="{Binding WordOverlay }" Foreground="{DynamicResource TextColor}"/>
-                    <Label FontSize="50" x:Name="WordOverlayWrong" Content="{Binding WordOverlayWrong}" Foreground="Red"/>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <TextBox x:Name="UserInput" Background="Transparent" Foreground="Transparent" CaretBrush="Transparent" Grid.Column="0" LostKeyboardFocus="UserInput_LostFocus" Text="" TextChanged="UserInput_TextChanged" SelectionBrush="{x:Null}" BorderThickness="0,0,0,0"/>
+                <Grid Grid.Row="0" Grid.RowSpan="3">
+                    <ListBox x:Name="OpponentListBox" ItemContainerStyle="{DynamicResource ListBoxItemTemplate}" Background="Transparent" BorderThickness="0" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,0,0,200">
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <UniformGrid Columns="2"/>
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                    </ListBox>
                 </Grid>
-            </Border>
-        </Grid>
-        <Grid>
-            <ProgressBar Background="{DynamicResource Color4}" Template="{DynamicResource ProgressBar}" VerticalAlignment="Bottom" Height="20" Minimum="0" Maximum="{Binding MaxLetters}" Value="{Binding LettersTyped, Mode=OneWay}"/>
-            <TextBox x:Name="TimerTextBox" Style="{DynamicResource TextBox2}" VerticalAlignment="Top" Background="Transparent"  Text="00:00" Height="53"  Margin="10,11,133,0"/>
-            <Button Style="{DynamicResource Button1}" Content="Exit" VerticalAlignment="Top" HorizontalAlignment="Right" Click="ButtonExit" FontSize="26" Margin="0,11,10,0"  Height="54" Width="110"/>
-        </Grid>
-        <TextBlock Style="{DynamicResource TextBlock}" Background="Transparent" x:Name="points" HorizontalAlignment="Center"
+                <Grid Grid.Row="0" Margin="30,30,30,0">
+                    <TextBlock Visibility="Hidden" Style="{DynamicResource TextBlock}" Background="Transparent" x:Name="points" HorizontalAlignment="Center"
                     VerticalAlignment="Top" Height="40" Width="116"
-                    TextWrapping="Wrap" Text="0p" TextAlignment="Center" Margin="0,16,0,0">
-        </TextBlock>
+                    TextWrapping="Wrap" Text="0p" TextAlignment="Center"/>
+                    <TextBox BorderThickness="0" x:Name="TimerTextBox" Style="{DynamicResource TextBox2}" VerticalAlignment="Center" Background="Transparent"  Text="00:00"/>
+                    <Button Style="{DynamicResource Button1}" Content="Afsluiten" VerticalAlignment="Top" HorizontalAlignment="Right" Click="ButtonExit" FontSize="26"/>
+                </Grid>
+                <Grid Margin="100,0" Grid.Row="1" Grid.RowSpan="2" HorizontalAlignment="Center" VerticalAlignment="Center" TextOptions.TextFormattingMode="Display">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.OpacityMask>
+                        <LinearGradientBrush EndPoint="1,0"
+                                 StartPoint="0,0">
+                            <GradientStop Color="Transparent"
+                                                  Offset="0" />
+                            <GradientStop Color="White" 
+                                                  Offset="0.02"/>
+                            <GradientStop Color="White"
+                                                  Offset="0.98" />
+                            <GradientStop Color="Transparent" 
+                                                  Offset="1"/>
+                        </LinearGradientBrush>
+                    </Grid.OpacityMask>
+                    <Grid>
+                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Right" FontSize="50" x:Name="WordOverlayCorrect" Text="{Binding WordOverlayCorrect}" Foreground="Green"/>
+                    </Grid>
+                    <Border Grid.Column="1" BorderThickness="3, 0, 0, 0">
+                        <Border.BorderBrush>
+                            <DrawingBrush Viewport="0,0,8,22" ViewportUnits="Absolute" TileMode="Tile">
+                                <DrawingBrush.Drawing>
+                                    <DrawingGroup>
+                                        <GeometryDrawing Brush="{DynamicResource TextColor}">
+                                            <GeometryDrawing.Geometry>
+                                                <GeometryGroup>
+                                                    <RectangleGeometry Rect="0,0,50,50" />
+                                                    <RectangleGeometry Rect="50,50,0,50" />
+                                                </GeometryGroup>
+                                            </GeometryDrawing.Geometry>
+                                        </GeometryDrawing>
+                                    </DrawingGroup>
+                                </DrawingBrush.Drawing>
+                            </DrawingBrush>
+                        </Border.BorderBrush>
+                        <Grid>
+                            <Label FontSize="50" x:Name="WordOverlay" Content="{Binding WordOverlay }" Foreground="{DynamicResource TextColor}"/>
+                            <Label FontSize="50" x:Name="WordOverlayWrong" Content="{Binding WordOverlayWrong}" Foreground="Red"/>
+                        </Grid>
+                    </Border>
+                </Grid>
+                <Grid Grid.Row="2">
+                    <ProgressBar Background="{DynamicResource Color4}" Template="{DynamicResource ProgressBar}" VerticalAlignment="Bottom" Height="20" Minimum="0" Maximum="{Binding MaxLetters}" Value="{Binding LettersTyped, Mode=OneWay}"/>
+                </Grid>
+            </Grid>
+        </Border>
     </Grid>
 </local:JumpPage>

--- a/KeyboardKing/areas/play/MatchWaitingResultPage.xaml
+++ b/KeyboardKing/areas/play/MatchWaitingResultPage.xaml
@@ -15,7 +15,7 @@
             VerticalAlignment="Center" 
             Height="400" Width="750" >
         <Grid>
-            <Label Style="{DynamicResource H1}" Content="Waiting on other players..." HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <Label Style="{DynamicResource H1}" Content="Wachten op andere spelers..." HorizontalAlignment="Center" VerticalAlignment="Center"/>
         </Grid>
     </Border>
 </local:JumpPage>


### PR DESCRIPTION
Changed "Waiting for players..." to "Wachten op spelers..."

Temporary hide the points textbox and matching layout on both play pages.

### **EpisodePlay.xaml**
<img src="https://user-images.githubusercontent.com/70901975/145848998-0f9b07d5-57e9-4343-9fd7-3935346a1f79.png" height="400"/>

### **MatchPlayingPage.xaml**
<img src="https://user-images.githubusercontent.com/70901975/145848912-e304b2bd-0bb1-4b73-ad40-f228eb53b2e1.png" height="400"/>
