### PR TITLE
Added tooltip styling for navigationbuttons

### DIFF
--- a/KeyboardKing/MyStyle.xaml
+++ b/KeyboardKing/MyStyle.xaml
@@ -182,15 +182,18 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid x:Name="grid" Background="Transparent">
+                    <Grid x:Name="grid" Background="Transparent" ToolTipService.InitialShowDelay="0">
                         <Border Name="border" 
                         BorderThickness="1"
                         Padding="4,2" 
                         BorderBrush="{DynamicResource Color4}" 
                         CornerRadius="3" 
                         Background="{TemplateBinding Background}">
-                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                         </Border>
+                        <Grid.ToolTip>
+                            <ToolTip Style="{DynamicResource NavBarToolTip}" Content="{TemplateBinding ToolTip}"/>
+                        </Grid.ToolTip>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
@@ -1090,4 +1093,43 @@
         </Style.Triggers>
     </Style>
 
+
+    <!-- NavBarToolTip Template -->
+    <Style x:Key="NavBarToolTip" TargetType="ToolTip">
+        <Setter Property="OverridesDefaultStyle"
+          Value="true" />
+        <Setter Property="HasDropShadow"
+          Value="True" />
+        <Setter Property="FontSize" Value="18"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="Placement" Value="Center"/>
+        <Setter Property="VerticalOffset" Value="60"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToolTip">
+                    <Border Name="Border"
+                BorderThickness="1"
+                Width="{TemplateBinding Width}"
+                Height="{TemplateBinding Height}"
+                            Background="{DynamicResource Color5}">
+                        <ContentPresenter Margin="4"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="HasDropShadow"
+                   Value="true">
+                            <Setter TargetName="Border"
+                    Property="CornerRadius"
+                    Value="3" />
+                            <Setter TargetName="Border"
+                    Property="SnapsToDevicePixels"
+                    Value="true" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
 </ResourceDictionary>

--- a/KeyboardKing/components/Navbar.xaml
+++ b/KeyboardKing/components/Navbar.xaml
@@ -10,11 +10,11 @@
     <Grid>
         <DockPanel>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" DockPanel.Dock="Bottom" Height="92" Background="{x:Null}" Margin="0,0,0,10">
-                <Components:NavigationButton ToPage="ChaptersPage" Style="{DynamicResource NavButton}" x:Name="Button_ChaptersPage" Content="▶" FontSize="36"/>
-                <Components:NavigationButton ToPage="FavoritesPage" Style="{DynamicResource NavButton}" x:Name="Button_FavoritesPage" Content="🔄" FontSize="30"/>
-                <Components:NavigationButton ToPage="MatchOverviewPage" Style="{DynamicResource NavButton}" x:Name="Button_MatchOverviewPage" Content="⚔" FontSize="30"/>
-                <Components:NavigationButton ToPage="SettingsPage" Style="{DynamicResource NavButton}" x:Name="Button_SettingsPage" Content="⚙" FontSize="30"/>
-                <Components:NavigationButton ToPage="LoginPage" Style="{DynamicResource NavButton}" Content="🚪" FontSize="30"/>
+                <Components:NavigationButton ToolTip="Chapters" ToPage="ChaptersPage" Style="{DynamicResource NavButton}" x:Name="Button_ChaptersPage" Content="▶" FontSize="36"/>
+                <Components:NavigationButton ToolTip="Favorieten" ToPage="FavoritesPage" Style="{DynamicResource NavButton}" x:Name="Button_FavoritesPage" Content="🔄" FontSize="30"/>
+                <Components:NavigationButton ToolTip="Matches" ToPage="MatchOverviewPage" Style="{DynamicResource NavButton}" x:Name="Button_MatchOverviewPage" Content="⚔" FontSize="30"/>
+                <Components:NavigationButton ToolTip="Instellingen" ToPage="SettingsPage" Style="{DynamicResource NavButton}" x:Name="Button_SettingsPage" Content="⚙" FontSize="30"/>
+                <Components:NavigationButton ToolTip="Uitloggen" ToPage="LoginPage" Style="{DynamicResource NavButton}" Content="🚪" FontSize="30"/>
             </StackPanel>
             <StackPanel></StackPanel>
         </DockPanel>


### PR DESCRIPTION
Hovering on a button now shows a tooltip about the button its purpose.

![image](https://user-images.githubusercontent.com/70901975/146031916-545cb671-8699-4ac0-9e0a-d28b3001a664.png)
