### PR TITLE
Fix layout progressbars in MatchPlayPage

### DIFF
--- a/KeyboardKing/areas/play/MatchPlayingPage.xaml
+++ b/KeyboardKing/areas/play/MatchPlayingPage.xaml
@@ -47,11 +47,11 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <TextBox x:Name="UserInput" Background="Transparent" Foreground="Transparent" CaretBrush="Transparent" Grid.Column="0" LostKeyboardFocus="UserInput_LostFocus" Text="" TextChanged="UserInput_TextChanged" SelectionBrush="{x:Null}" BorderThickness="0,0,0,0"/>
-                <Grid Grid.Row="0" Grid.RowSpan="3">
-                    <ListBox x:Name="OpponentListBox" ItemContainerStyle="{DynamicResource ListBoxItemTemplate}" Background="Transparent" BorderThickness="0" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,0,0,200">
+                <Grid Grid.Row="1" Grid.RowSpan="2">
+                    <ListBox MaxWidth="800" x:Name="OpponentListBox" ItemContainerStyle="{DynamicResource ListBoxItemTemplate}" Background="Transparent" BorderThickness="0" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,30,0,0">
                         <ListBox.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <UniformGrid Columns="2"/>
+                                <WrapPanel HorizontalAlignment="Center"/>
                             </ItemsPanelTemplate>
                         </ListBox.ItemsPanel>
                     </ListBox>


### PR DESCRIPTION
Fix layout progressbars in MatchPlayPage. Progressbars also gets centered now.

![image](https://user-images.githubusercontent.com/70901975/146177794-8412b0c8-a06b-4506-ab75-5cd5640455f1.png)
![image](https://user-images.githubusercontent.com/70901975/146177766-e39470d0-b800-4bd6-b9c8-3fc1dbf7a660.png)

