### PR TITLE
Added improvements

### DIFF
--- a/Controller/EpisodeController.cs
+++ b/Controller/EpisodeController.cs
@@ -190,29 +190,29 @@ namespace Controller
         {
             StopAndSetEpisodeResult();
            
-
             User student = (User)Session.Get("student");
             int episodeId = (int)Session.Get("episodeId");
-            GiveCoins(CurrentEpisodeResult.Score, student, episodeId);
+            GiveCoins(student, episodeId);
             DBQueries.SaveResult(CurrentEpisodeResult, episodeId, student.Id);
 
             EpisodeResultUpdated?.Invoke(null, EventArgs.Empty);
             NavigationController.NavigateToPage(Pages.EpisodeResultPage);
         }
 
-        private static void GiveCoins(int score, User student, int episodeId)
+        private static void GiveCoins(User student, int episodeId)
         {
             int highscore = DBQueries.GetHighscoreEpisode(student, episodeId); //5550
 
             if(CurrentEpisodeResult.Score > highscore)
-            {
                 Coins = (CurrentEpisodeResult.Score - highscore) / 100;
-            }
 
             DBQueries.UpdateCoins(Coins, student);
+
+            student.Coins = DBQueries.GetCoinsOffUser(student);
+            Session.Add("student", student);
         }
         
-        public static string GetCoins(User student)
+        public static int GetCoins(User student)
         {
             return DBQueries.GetCoinsOffUser(student);
         }

--- a/Controller/Session.cs
+++ b/Controller/Session.cs
@@ -8,7 +8,10 @@ namespace Controller
 {
     public static class Session
     {
-        private static Dictionary<string, object> Data {get;set;} = new Dictionary<string, object>();
+
+        public static event EventHandler PropertyChanged;
+
+        private static Dictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
 
         public static object Get(string key)
         {
@@ -21,7 +24,8 @@ namespace Controller
                 Data.Remove(key);
 
             Data.Add(key, o);
-                return true;
+            PropertyChanged?.Invoke(null, EventArgs.Empty);
+            return true;
         }
 
         public static bool Remove(string key)

--- a/DatabaseController/DBQueries.cs
+++ b/DatabaseController/DBQueries.cs
@@ -105,7 +105,7 @@ namespace Controller
 
         public static User GetUserInfo(string email)
         {
-            MySqlCommand cmd = new MySqlCommand("SELECT id, username, email, password, salt, skilllevel " +
+            MySqlCommand cmd = new MySqlCommand("SELECT id, username, email, password, salt, skilllevel, coins " +
                                             "FROM User " +
                                             "LEFT JOIN UserSettings " +
                                             "ON User.id = UserSettings.userid " +
@@ -156,12 +156,12 @@ namespace Controller
 
             List<List<string>> result = DBHandler.SelectQuery(cmd);
    
-            return !String.IsNullOrEmpty(result[0][0]) ? int.Parse(result[0][0]) : 0;
+            return !string.IsNullOrEmpty(result[0][0]) ? int.Parse(result[0][0]) : 0;
         }
 
         public static void UpdateCoins(int coins, User user)
         {
-            MySqlCommand cmd = new MySqlCommand("UPDATE User set coins = coins + @coins WHERE id = @userid");
+            MySqlCommand cmd = new MySqlCommand("UPDATE User SET coins = coins + @coins WHERE id = @userid");
 
             MySqlParameter CoinsIdParam = new MySqlParameter("@coins", MySqlDbType.Int32, 0);
             MySqlParameter UserIdParam = new MySqlParameter("@userid", MySqlDbType.Int32, 0);
@@ -175,7 +175,7 @@ namespace Controller
             DBHandler.Query(cmd);
         }
 
-        public static string GetCoinsOffUser(User user)
+        public static int GetCoinsOffUser(User user)
         {
             MySqlCommand cmd = new MySqlCommand("SELECT coins From User WHERE id = @userid");
 
@@ -187,7 +187,7 @@ namespace Controller
 
             List<List<string>> result = DBHandler.SelectQuery(cmd);
 
-            return result[0][0];
+            return int.Parse(result[0][0]);
         }
 
 

--- a/KeyboardKing/areas/main/ChaptersPage.xaml
+++ b/KeyboardKing/areas/main/ChaptersPage.xaml
@@ -76,7 +76,7 @@
                 </Grid.RowDefinitions>
                 <Grid Grid.Row="0" VerticalAlignment="Center">
                     <Label Style="{DynamicResource H1}" Content="Chapters" HorizontalAlignment="Left"/>
-                    <Components:CoinsComp CurrentPage2="ChaptersPage"/>
+                    <Components:CoinsComp/>
                 </Grid>
                 <Grid Grid.Row="1" VerticalAlignment="Top">
                     <!-- Chapter overview ListBox -->

--- a/KeyboardKing/areas/main/FavoritesPage.xaml.cs
+++ b/KeyboardKing/areas/main/FavoritesPage.xaml.cs
@@ -30,7 +30,6 @@ namespace KeyboardKing.areas.main
 
         public override void OnLoad()
         {
-            Coin.Content = EpisodeController.GetCoins((User)Session.Get("student"));
         }
 
         public override void OnShadow()

--- a/KeyboardKing/areas/play/EpisodeResultPage.xaml.cs
+++ b/KeyboardKing/areas/play/EpisodeResultPage.xaml.cs
@@ -50,7 +50,7 @@ namespace KeyboardKing.areas.play
 
         private static string ShowCoins()
         {
-            int coins = int.Parse(EpisodeController.GetCoins((User)Session.Get("student"))) - EpisodeController.Coins;
+            int coins = EpisodeController.GetCoins((User)Session.Get("student")) - EpisodeController.Coins;
 
             return $"{coins} + {EpisodeController.Coins}";
         }

--- a/KeyboardKing/components/CoinsComp.xaml.cs
+++ b/KeyboardKing/components/CoinsComp.xaml.cs
@@ -13,30 +13,17 @@ namespace KeyboardKing.components
     
     public partial class CoinsComp : UserControl
     {
-        public event EventHandler Load;
-        public Pages CurrentPage2 { get; set; } = Pages.Empty;
-
         public CoinsComp()
         {
             InitializeComponent();
-            CoinsChange();
+            Session.PropertyChanged += OnCoinsChange;
         }
 
-        private void UserControl1_Load(Object sender, EventArgs e)
+        public void OnCoinsChange(object sender, EventArgs e)
         {
-
-            MessageBox.Show("You are in the UserControl.Load event.");
-        }
-
-        public void CoinsChange()
-        {
-            if(CurrentPage2 == Pages.ChaptersPage)
-            {
-                Coins.Content = EpisodeController.GetCoins((User)Session.Get("student"));
-            }else
-            {
-                Coins.Content = "2";
-            }
+            User user = (User)Session.Get("student");
+            if (user != null)
+                Coins.Content = user.Coins;
         }
     }
 }

--- a/Model/User.cs
+++ b/Model/User.cs
@@ -18,6 +18,7 @@ namespace Model
         public string Password { get; set; }
         public string Salt { get; set; }
         public SkillLevel SkillLevel { get; set; }
+        public int Coins { get; set; }
 
         public static List<User> ParseUserIds(List<List<string>> input)
         {
@@ -35,7 +36,8 @@ namespace Model
                     Email = input[0][2],
                     Password = input[0][3],
                     Salt = input[0][4],
-                    SkillLevel = (SkillLevel)Enum.Parse(typeof(SkillLevel), input[0][5])
+                    SkillLevel = (SkillLevel)Enum.Parse(typeof(SkillLevel), input[0][5]),
+                    Coins = int.Parse(input[0][6])
                 };
             }
             return null;


### PR DESCRIPTION
Switched a few things around, fixed coins display with an event.
If something in the Session get's added the `PropertyChanged` event is fired.
This could be later improved by specifying what has changed or just switch to `ObervableDictionary`
(https://docs.microsoft.com/en-us/dotnet/api/microsoft.identityserver.management.resources.observabledictionary-2?view=adfs-2019)

