### PR TITLE
Coin placement fix in shopping page

### DIFF
--- a/KeyboardKing/areas/main/ChaptersPage.xaml
+++ b/KeyboardKing/areas/main/ChaptersPage.xaml
@@ -78,7 +78,7 @@
                 </Grid.RowDefinitions>
                 <Grid Grid.Row="0" VerticalAlignment="Center">
                     <Label Style="{DynamicResource H1}" Content="Chapters" HorizontalAlignment="Left"/>
-                    <Components:CoinsComp/>
+                    <Components:CoinsComp HorizontalAlignment="Right"/>
                 </Grid>
                 <Grid Grid.Row="1" VerticalAlignment="Top">
                     <!-- Chapter overview ListBox -->

--- a/KeyboardKing/areas/main/ShoppingPage.xaml
+++ b/KeyboardKing/areas/main/ShoppingPage.xaml
@@ -109,7 +109,7 @@
                                         </ItemsPanelTemplate>
                                     </ListBox.ItemsPanel>
                                 </ListBox>
-                                <Components:CoinsComp HorizontalAlignment="Right" VerticalAlignment="Top"/>
+                               
                                 <!-- PreviousPage Button -->
                                 <Button RenderOptions.BitmapScalingMode="HighQuality" x:Name="PreviousPage" Tag="/KeyBoardking;component/resources/images/wooden_arrow.png" Margin="10" HorizontalAlignment="Left" Width="75" Height="75" Style="{DynamicResource ImageButtonTemplate}" RenderTransformOrigin="0.5,0.5" Click="PreviousPage_Click">
                                     <Button.RenderTransform>
@@ -128,13 +128,23 @@
                                 </Button>
                             </Grid>
                         </DockPanel>
-                        
-                        <Grid VerticalAlignment="Top" Margin="0,-20,0,0" Width="150" Height="50" Background="#c6750d">
-                            <Label HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Foreground="#FF6C4006" Style="{DynamicResource H2}" Content="Winkel"/>
+
+                        <Grid VerticalAlignment="Top" Margin="0,-20,0,0" Width="175" Height="60" Background="#c6750d">
+                            <Label HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Foreground="#FF6C4006" Style="{DynamicResource H1}" Content="Winkel"/>
+                            
                             <Grid.Effect>
                                 <DropShadowEffect ShadowDepth="0" BlurRadius="20" Opacity="0.5" Color="Black"/>
                             </Grid.Effect>
                         </Grid>
+
+                        <Border Padding="5" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,-20,30,0" Height="60" Background="#c6750d">
+                            <Grid>
+                                <Components:CoinsComp HorizontalAlignment="Right" VerticalAlignment="Top"/>
+                            </Grid>
+                            <Border.Effect>
+                                <DropShadowEffect ShadowDepth="0" BlurRadius="20" Opacity="0.5" Color="Black"/>
+                            </Border.Effect>
+                        </Border>
                     </Grid>
                     
                     <Grid Grid.Row="1" HorizontalAlignment="Center">

--- a/KeyboardKing/areas/play/EpisodeResultPage.xaml
+++ b/KeyboardKing/areas/play/EpisodeResultPage.xaml
@@ -29,7 +29,7 @@
             <Grid Grid.Row="0" VerticalAlignment="Center">
                 <Label Style="{DynamicResource H1}" HorizontalAlignment="Left" Content="Results"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Image Width="50" Source="/KeyBoardking;component/resources/images/coin.png"/>
+                    <Image Width="50" Source="/KeyBoardking;component/resources/images/icons/coin.png"/>
                     <Label Style="{DynamicResource H1}" x:Name="Coin" Content=""/>
                 </StackPanel>
             </Grid>

--- a/KeyboardKing/components/CoinsComp.xaml
+++ b/KeyboardKing/components/CoinsComp.xaml
@@ -5,12 +5,11 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:Components="clr-namespace:KeyboardKing.components"
              mc:Ignorable="d" 
-             x:Name="root"
-             d:DesignHeight="450" d:DesignWidth="800">
+             x:Name="root">
     <Grid>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+        <StackPanel Orientation="Horizontal">
             <Image Width="50" Source="/KeyBoardking;component/resources/images/icons/coin.png"/>
-            <Label Style="{DynamicResource H1}" x:Name="Coins" Content=""/>
+            <Label Style="{DynamicResource H1}" Padding="5,3,5,0" x:Name="Coins"/>
         </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
The original idea was to place the coin on the right side where the navbar is placed. Since we have more content and more navbuttons, this fix cannot be done. 

Instead, all original coin placements are kept the same. Only the shopping page coin placement got fixed by matching the design of the shop by adding the sign.

![image](https://user-images.githubusercontent.com/70901975/147381695-95b7de26-a135-4926-b4e2-baa1729b954d.png)
